### PR TITLE
add needed header for usb_reset

### DIFF
--- a/ujprog/ujprog.c
+++ b/ujprog/ujprog.c
@@ -57,6 +57,10 @@ static const char *verstr = "ULX2S / ULX3S JTAG programmer v 3.0.92";
 #define USE_PPI
 #endif
 
+#if defined(__linux__)
+#include <usb.h>
+#endif
+
 #if defined(__linux__) || defined(WIN32)
 #define isnumber(x) (x >= '0' && x <= '9')
 #endif


### PR DESCRIPTION
Fix following warning:
ujprog.c:836:2: warning: implicit declaration of function ‘usb_reset’;
did you mean ‘ftdi_usb_reset’? [-Wimplicit-function-declaration]