### PR TITLE
build on Alpine Linux, require libusb 1.0.9 (2008)

### DIFF
--- a/ujprog/Makefile.linux
+++ b/ujprog/Makefile.linux
@@ -7,9 +7,9 @@ ARCHNAME = $(shell uname -m)-linux-gnu
 # for linux on raspberrypi-3
 # ARCHNAME = arm-linux-gnueabihf
 
-FTLIB = /usr/lib/${ARCHNAME}/libftdi.a
+FTLIB ?= /usr/lib/${ARCHNAME}/libftdi.a
 #FTLIB = -lftdi
-USBLIB = /usr/lib/${ARCHNAME}/libusb.a
+USBLIB ?= /usr/lib/${ARCHNAME}/libusb.a
 
 ujprog:	${SRCS}
 	${CC} ${CFLAGS} ${SRCS} ${FTLIB} ${USBLIB} -o ujprog

--- a/ujprog/ujprog.c
+++ b/ujprog/ujprog.c
@@ -75,6 +75,7 @@ static const char *verstr = "ULX3S JTAG programmer v 3.4";
 #include <dev/ppbus/ppi.h>
 #include <dev/ppbus/ppbconf.h>
 #endif
+#include <libusb.h>
 #include <ftdi.h>
 #endif
 
@@ -1045,7 +1046,7 @@ shutdown_usb(void)
 	}
 
 #ifdef __linux__
-	usb_reset((void *) fc.usb_dev);
+	libusb_reset_device(fc.usb_dev);
 #else
 	res = ftdi_usb_close(&fc);
 	if (res < 0) {


### PR DESCRIPTION
I tried to build ujprog on Alpine Linux and ran into errors:

<details>

```
~/tools/ujprog $ make -B -f Makefile.linux 
cc -Wall -D__linux__ -std=gnu99 -static ujprog.c /usr/lib/x86_64-linux-gnu/libftdi.a /usr/lib/x86_64-linux-gnu/libusb.a -o ujprog
ujprog.c:78:10: fatal error: ftdi.h: No such file or directory
   78 | #include <ftdi.h>
      |          ^~~~~~~~
compilation terminated.
make: *** [Makefile.linux:15: ujprog] Error 1
~/tools/ujprog $ env CFLAGS="-I /usr/include/libftdi1/ -I /usr/include/libusb-1.0/" FTLIB=/usr/lib/libftdi1.a 
USBLIB=/usr/lib/libusb-1.0.a make -B -f Makefile.linux 
cc -I /usr/include/libftdi1/ -I /usr/include/libusb-1.0/ -Wall -D__linux__ -std=gnu99 -static ujprog.c /usr/lib/x86_64-linux-gnu/libftdi.a /usr/lib/x86_64-linux-gnu/libusb.a -o ujprog
ujprog.c: In function 'shutdown_usb':
ujprog.c:1048:9: error: implicit declaration of function 'usb_reset'; did you mean 'ftdi_usb_reset'? [-Wimplicit-function-declaration]
 1048 |         usb_reset((void *) fc.usb_dev);
      |         ^~~~~~~~~
      |         ftdi_usb_reset
ujprog.c: In function 'txfile':
ujprog.c:3338:17: warning: 'ftdi_usb_purge_buffers' is deprecated [-Wdeprecated-declarations]
 3338 |                 ftdi_usb_purge_buffers(&fc);
      |                 ^~~~~~~~~~~~~~~~~~~~~~
In file included from ujprog.c:78:
/usr/include/libftdi1/ftdi.h:566:20: note: declared here
  566 |     int DEPRECATED(ftdi_usb_purge_buffers(struct ftdi_context *ftdi));
      |                    ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/libftdi1/ftdi.h:247:55: note: in definition of macro 'DEPRECATED'
  247 | #define DEPRECATED(func) __attribute__ ((deprecated)) func
      |                                                       ^~~~
ujprog.c: In function 'term_emul':
ujprog.c:3936:25: warning: 'ftdi_usb_purge_buffers' is deprecated [-Wdeprecated-declarations]
 3936 |                         ftdi_usb_purge_buffers(&fc);
      |                         ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/libftdi1/ftdi.h:566:20: note: declared here
  566 |     int DEPRECATED(ftdi_usb_purge_buffers(struct ftdi_context *ftdi));
      |                    ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/libftdi1/ftdi.h:247:55: note: in definition of macro 'DEPRECATED'
  247 | #define DEPRECATED(func) __attribute__ ((deprecated)) func
      |                                                       ^~~~
make: *** [Makefile.linux:15: ujprog] Error 1

```

</details>


This PR is the patch that got me to a successful build with the following command:

```
env CFLAGS="-I /usr/include/libftdi1/ -I /usr/include/libusb-1.0/" FTLIB=/usr/lib/libftdi1.a USBLIB=/usr/lib/libusb-1.0.a make -B -f Makefile.linux
```

I believe the libusb change bumps the minimum version requirement for libusb to what looks like [1.0.9 from 2008](https://github.com/libusb/libusb/commit/bfe74e9cd9c17a40fff042ea0647326f51cfecae). Alternatively, fujprog seems to have [similar changes](https://github.com/kost/fujprog/blob/master/fujprog.c#L1003-L1017) that also work for me.

Thanks!